### PR TITLE
feat(ci): simple testing ci setup with dependency caching

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,23 +1,88 @@
 name: test
 
+env:
+  GLEAM_VERSION: "1.1.0-rc3"
+
 on:
   push:
     branches:
-      - master
       - main
   pull_request:
 
 jobs:
-  test:
+  format:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: erlef/setup-beam@v1
         with:
-          otp-version: "26.0.2"
-          gleam-version: "1.0.0"
-          rebar3-version: "3"
-          # elixir-version: "1.15.4"
-      - run: gleam deps download
-      - run: gleam test
+          otp-version: 26
+          rebar3-version: 3
+          gleam-version: ${{ env.GLEAM_VERSION }}
       - run: gleam format --check src test
+
+  deps:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check cache
+        uses: actions/cache/restore@v4
+        id: restore
+        with:
+          path: ./build/packages
+          key: deps-${{ hashFiles('manifest.toml') }}
+      - if: ${{ steps.restore.outputs.cache-hit != 'true' }}
+        uses: erlef/setup-beam@v1
+        with:
+          otp-version: 26
+          rebar3-version: 3
+          gleam-version: ${{ env.GLEAM_VERSION }}
+      - if: ${{ steps.restore.outputs.cache-hit != 'true' }}
+        run: gleam deps download
+      - if: ${{ steps.restore.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: ./build/packages
+          key: deps-${{ hashFiles('manifest.toml') }}
+
+  test_erlang:
+    runs-on: ubuntu-latest
+    needs: deps
+    strategy:
+      fail-fast: true
+      matrix:
+        erlang: ["26", "25", "27.0-rc1"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/cache/restore@v4
+        with:
+          path: ./build/packages
+          key: deps-${{ hashFiles('manifest.toml') }}
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: ${{matrix.erlang}}
+          rebar3-version: 3
+          gleam-version: ${{env.GLEAM_VERSION}}
+      - run: gleam test --target erlang
+
+  test_node:
+    runs-on: ubuntu-latest
+    needs: deps
+    strategy:
+      fail-fast: true
+      matrix:
+        node: ["20", "18"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/cache/restore@v4
+        with:
+          path: ./build/packages
+          key: deps-${{ hashFiles('manifest.toml') }}
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: 26
+          gleam-version: ${{env.GLEAM_VERSION}}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{matrix.node}}
+      - run: gleam test --target javascript

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *.ez
 /build
 erl_crash.dump
+.mise.toml
+.tool-versions

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+.github/ @tanklesxl
+
+* @bcpeinhardt @tanklesxl @giacomocavalieri

--- a/src/rule.gleam
+++ b/src/rule.gleam
@@ -1,5 +1,5 @@
-import gleam/option
 import glance
+import gleam/option
 
 pub type Rule {
   Rule(

--- a/src/rules/no_panic.gleam
+++ b/src/rules/no_panic.gleam
@@ -1,5 +1,5 @@
-import gleam/option
 import glance
+import gleam/option
 import rule.{type Rule, type RuleError, Rule}
 
 pub const rule: Rule = Rule(

--- a/src/rules/no_unnecessary_string_concatenation.gleam
+++ b/src/rules/no_unnecessary_string_concatenation.gleam
@@ -1,5 +1,5 @@
-import gleam/option
 import glance
+import gleam/option
 import rule.{type Rule, type RuleError, Rule}
 
 pub const rule: Rule = Rule(
@@ -24,10 +24,10 @@ pub fn unnecessary_concatenation_expression_visitor(
       ]
     }
     glance.BinaryOperator(
-      glance.Concatenate,
-      glance.String(_),
-      glance.String(_),
-    ) -> {
+        glance.Concatenate,
+        glance.String(_),
+        glance.String(_),
+      ) -> {
       [
         rule.error(
           message: "Unnecessary concatenation of string literals",

--- a/src/whinge.gleam
+++ b/src/whinge.gleam
@@ -11,10 +11,10 @@ import gleam/list
 import gleam/option.{None, Some}
 import gleam/result
 import gleam/string
-import simplifile
-import tom
 import review_config.{config}
 import rule.{type Rule, type RuleError, Rule, RuleError}
+import simplifile
+import tom
 
 pub type WhingeError {
   CouldNotGetCurrentDirectory
@@ -271,11 +271,11 @@ fn do_visit_expressions(
       }
     }
     glance.RecordUpdate(
-      module: _,
-      constructor: _,
-      record: record,
-      fields: fields,
-    ) -> {
+        module: _,
+        constructor: _,
+        record: record,
+        fields: fields,
+      ) -> {
       {
         use sub_acc, #(_, expr) <- list.fold(fields, acc)
         do_visit_expressions(expr, sub_acc, f)
@@ -294,11 +294,11 @@ fn do_visit_expressions(
       do_visit_expressions(tuple, acc, f)
     }
     glance.FnCapture(
-      label: _,
-      function: function,
-      arguments_before: arguments_before,
-      arguments_after: arguments_after,
-    ) -> {
+        label: _,
+        function: function,
+        arguments_before: arguments_before,
+        arguments_after: arguments_after,
+      ) -> {
       list.fold(
         list.append(arguments_before, arguments_after),
         acc,

--- a/test/whinge_test.gleam
+++ b/test/whinge_test.gleam
@@ -1,5 +1,5 @@
-import gleam/list
 import birdie
+import gleam/list
 import gleeunit
 import whinge
 


### PR DESCRIPTION
This change sets up CI with dependency caching and matrix testing for both erlang and javascript targets.

- Erlang: 26,25,27.0-rc1
- Node: 20, 18

the `deps` job is an explicit dependency of the testing jobs, the format job is separate and does not require it.

Caveats: 
- due to how `setup-beam` works currently, an erlang and rebar3 version are always required even if only gleam is needed (for example when running on the JS target). this could be removed later in favour of installing the binary directly from github releases but isnt a huge issue atm